### PR TITLE
課題6（画像投稿機能追加）

### DIFF
--- a/.github/workflows/laravel-testing.yml
+++ b/.github/workflows/laravel-testing.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           docker-compose -f docker-compose-test.yml exec -T web cp .env.testing .env
           docker-compose -f docker-compose-test.yml exec -T web php artisan key:generate
+          docker-compose -f docker-compose-test.yml exec -T web php artisan storage:link
 
       - name: Laravel Migrate Testing
         run: docker-compose -f docker-compose-test.yml exec -T web php artisan migrate

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ docker-compose exec web bash
 $ composer install
 $ php artisan optimize
 $ php artisan migrate
+$ php artisan storage:link
 ```
 
 ## Seeding

--- a/infra/php/Dockerfile
+++ b/infra/php/Dockerfile
@@ -7,10 +7,12 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
 COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && \
-  apt-get -y install --no-install-recommends git unzip libzip-dev libicu-dev libonig-dev && \
+  apt-get -y install --no-install-recommends git unzip libzip-dev libicu-dev libonig-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   docker-php-ext-install intl pdo_mysql zip bcmath && \
+  docker-php-ext-configure gd --with-freetype --with-jpeg && \
+  docker-php-ext-install -j$(nproc) gd && \
   pecl install xdebug && \
   docker-php-ext-enable xdebug
 

--- a/src/app/Http/Controllers/ReplyController.php
+++ b/src/app/Http/Controllers/ReplyController.php
@@ -17,6 +17,7 @@ class ReplyController extends Controller
      * Replyボタン押下時の処理
      *
      * 返信を保存し、再度メインページを開く
+     * 画像があれば、画像のパスをDBに保存する
      *
      * @param ReplyRequest $request
      * @return Redirector|RedirectResponse|Application
@@ -25,6 +26,13 @@ class ReplyController extends Controller
     {
         $reply = new Reply();
         $form = $request->all();
+        $image = $request->file('image');
+
+        if (!is_null($image)) {
+            $file_name = $image->getClientOriginalName();
+            $form['image'] = $image->storeAs('public', $file_name);
+        }
+
         unset($form['_token']);
         $reply->fill($form)->save();
         return redirect('/');

--- a/src/app/Http/Controllers/ReplyController.php
+++ b/src/app/Http/Controllers/ReplyController.php
@@ -30,7 +30,7 @@ class ReplyController extends Controller
 
         if (!is_null($image)) {
             $file_name = $image->getClientOriginalName();
-            $form['image'] = $image->storeAs('public', $file_name);
+            $form['image'] = $image->storeAs('public/images', $file_name);
         }
 
         unset($form['_token']);

--- a/src/app/Http/Controllers/ThreadController.php
+++ b/src/app/Http/Controllers/ThreadController.php
@@ -55,7 +55,7 @@ class ThreadController extends Controller
 
         if (!is_null($image)) {
             $file_name = $image->getClientOriginalName();
-            $form['image'] = $image->storeAs('public', $file_name);
+            $form['image'] = $image->storeAs('public/images', $file_name);
         }
 
         unset($form['_token']);

--- a/src/app/Http/Controllers/ThreadController.php
+++ b/src/app/Http/Controllers/ThreadController.php
@@ -50,6 +50,13 @@ class ThreadController extends Controller
     {
         $thread = new Thread();
         $form = $request->all();
+        $image = $request->file('image');
+
+        if (!is_null($image)) {
+            $file_name = $image->getClientOriginalName();
+            $image->storeAs('', $file_name);
+        }
+
         unset($form['_token']);
         $thread->fill($form)->save();
         return redirect('/');

--- a/src/app/Http/Controllers/ThreadController.php
+++ b/src/app/Http/Controllers/ThreadController.php
@@ -42,6 +42,7 @@ class ThreadController extends Controller
      * POSTボタン押下時の処理
      *
      * 投稿を保存し、再度メインページを開く
+     * 画像があれば、画像のパスをDBに保存する
      *
      * @param ThreadRequest $request
      * @return Redirector|RedirectResponse|Application
@@ -54,7 +55,7 @@ class ThreadController extends Controller
 
         if (!is_null($image)) {
             $file_name = $image->getClientOriginalName();
-            $image->storeAs('', $file_name);
+            $form['image'] = $image->storeAs('public', $file_name);
         }
 
         unset($form['_token']);

--- a/src/database/migrations/2022_04_07_010150_add_image_to_threads_table.php
+++ b/src/database/migrations/2022_04_07_010150_add_image_to_threads_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('threads', function (Blueprint $table) {
+            $table->string('image')->after('message')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('threads', function (Blueprint $table) {
+            $table->dropColumn('image');  //カラムの削除
+        });
+    }
+};

--- a/src/database/migrations/2022_04_13_020930_add_image_to_replies_table.php
+++ b/src/database/migrations/2022_04_13_020930_add_image_to_replies_table.php
@@ -1,0 +1,32 @@
+<?php
+
+    use Illuminate\Database\Migrations\Migration;
+    use Illuminate\Database\Schema\Blueprint;
+    use Illuminate\Support\Facades\Schema;
+
+    return new class extends Migration
+    {
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up(): void
+        {
+            Schema::table('replies', function (Blueprint $table) {
+                $table->string('image')->after('message')->nullable();
+            });
+        }
+
+        /**
+         * Reverse the migrations.
+         *
+         * @return void
+         */
+        public function down(): void
+        {
+            Schema::table('replies', function (Blueprint $table) {
+                $table->dropColumn('image');  //カラムの削除
+            });
+        }
+    };

--- a/src/resources/views/thread/index.blade.php
+++ b/src/resources/views/thread/index.blade.php
@@ -52,6 +52,7 @@
                         <p>{{$item->post_date}}</p>
                         <p>{{$item->author}}</p>
                         <p>{{$item->message}}</p>
+                        <img src="{{ \Illuminate\Support\Facades\Storage::url($item->image) }}" width="100px" alt="">
                     </div>
                     @if(!is_null($item->replies))
                         @foreach($item->replies as $obj)

--- a/src/resources/views/thread/index.blade.php
+++ b/src/resources/views/thread/index.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
     <section class="mt-8 mx-[auto] p-4 border-2 rounded-md">
-        <form action="/" method="post">
+        <form action="/" method="post" enctype="multipart/form-data">
             @csrf
             <div>
                 <div class="flex items-center mt-2">
@@ -23,6 +23,9 @@
                 @error('message')
                     <p class="text-red-500">{{$message}}</p>
                 @enderror
+            </div>
+            <div class="mt-2">
+                <input type="file" id="image" name="image">
             </div>
             <button type="submit" name="operation" value="post" class="mt-2 p-1 border-2 border-gray-700 rounded-md bg-gray-300">Post</button>
         </form>

--- a/src/resources/views/thread/index.blade.php
+++ b/src/resources/views/thread/index.blade.php
@@ -61,11 +61,12 @@
                                 <p>{{$obj->post_date}}</p>
                                 <p>{{$obj->author}}</p>
                                 <p>{{$obj->message}}</p>
+                                <img src="{{ \Illuminate\Support\Facades\Storage::url($obj->image) }}" width="100px" alt="">
                             </div>
                         @endforeach
                     @endif
                     <hr>
-                    <form action="/reply" method="post">
+                    <form action="/reply" method="post" enctype="multipart/form-data">
                         @csrf
                         <div>
                             <div class="flex items-center mt-2">
@@ -84,6 +85,9 @@
                             @error('message')
                             <p class="text-red-500">{{$message}}</p>
                             @enderror
+                        </div>
+                        <div class="mt-2">
+                            <input type="file" id="image" name="image">
                         </div>
                         <input type="hidden" name="thread_id" value="{{$item->entry_id}}">
                         <button type="submit" name="operation" value="post" class="mt-2 p-1 border-2 border-gray-700 rounded-md bg-gray-300">Reply</button>

--- a/src/tests/Feature/ReplyControllerTest.php
+++ b/src/tests/Feature/ReplyControllerTest.php
@@ -3,6 +3,8 @@
   namespace Tests\Feature;
 
   use Illuminate\Foundation\Testing\RefreshDatabase;
+  use Illuminate\Http\UploadedFile;
+  use Illuminate\Support\Facades\Storage;
   use Tests\TestCase;
 
 /**
@@ -27,6 +29,20 @@ class ReplyControllerTest extends TestCase
             'author' => 'test',
             'message' => 'reply test'
         ])->assertRedirect('/');
+
+
+        // image post success
+        Storage::fake('local');
+
+        $file = UploadedFile::fake()->image('test.png');
+        $this->post('/', [
+            'author' => 'test',
+            'message' => 'image post test',
+            'image' => $file
+        ])->assertRedirect('/');
+
+        Storage::disk('local')->assertExists('public/images/test.png');
+
 
         // post fail (validation error)
         $this->post('/reply', [

--- a/src/tests/Feature/ThreadControllerTest.php
+++ b/src/tests/Feature/ThreadControllerTest.php
@@ -4,6 +4,8 @@
 
   use App\Models\Thread;
   use Illuminate\Foundation\Testing\RefreshDatabase;
+  use Illuminate\Http\UploadedFile;
+  use Illuminate\Support\Facades\Storage;
   use Tests\TestCase;
 
 /**
@@ -50,13 +52,27 @@ class ThreadControllerTest extends TestCase
      *
      * @return void
      */
-    public function testCreate(): void
+    public function testStore(): void
     {
         // post success
         $this->post('/', [
-        'author' => 'test',
-        'message' => 'post test'
+            'author' => 'test',
+            'message' => 'post test'
         ])->assertRedirect('/');
+
+
+        // image post success
+        Storage::fake('local');
+
+        $file = UploadedFile::fake()->image('test.png');
+        $this->post('/', [
+            'author' => 'test',
+            'message' => 'image post test',
+            'image' => $file
+        ])->assertRedirect('/');
+
+        Storage::disk('local')->assertExists('public/images/test.png');
+
 
         // post fail (validation error)
         $this->post('/', [


### PR DESCRIPTION
## 課題6（画像投稿機能追加）
画像を投稿できるようにしてください。

## 概要
- 画像保存パス格納用のDBカラム追加
- 画像表示用のシンボリックリンク作成（GithubActionsにもフローの追加）
- GDの有効化（Dockerfile修正）
  - [Docker上でPHP拡張モジュール『GD』を有効化する](https://qiita.com/Soh1121/items/17dcdc815a1d22f31788)
- 画像アップロードテストの追加
  - [HTTPテスト 9.x Laravel](https://readouble.com/laravel/9.x/ja/http-tests.html)